### PR TITLE
Fix Update Plugins, modify dialog title, send process output to Unity console

### DIFF
--- a/Assets/Editor/MarkerMetro/PluginUpdateTool.cs
+++ b/Assets/Editor/MarkerMetro/PluginUpdateTool.cs
@@ -114,7 +114,7 @@ namespace Assets.Editor.MarkerMetro
         /// </summary>
         static void UpdateProgressBar ()
         {
-            // Stop updating if Unity is compiling
+            // Stop updating if Unity is compiling.
             if (EditorApplication.isCompiling)
             {
                 UpdateEnded();


### PR DESCRIPTION
Prevent plugin update when unity is compiling.
Modify dialog title.
Send process output to Unity console
