### PR TITLE
Remove Application.Quit() call

### DIFF
--- a/Assets/WinIntegrationExample/Scripts/GUIStart.cs
+++ b/Assets/WinIntegrationExample/Scripts/GUIStart.cs
@@ -87,13 +87,5 @@ public class GUIStart : MonoBehaviour {
         {
            throw new System.Exception("This is test exception from Unity code");
         }
-
-        y_modifier += 50;
-
-        // Third Button Login to Quit
-        if (GUI.Button(new Rect(box_x + 10, box_y + y_modifier, box_width - 20, 40), "Quit"))
-        {
-            Application.Quit();
-        }
     }
 }


### PR DESCRIPTION
Simply removed the button to quit the app as Application.Quit() is not supported (throws exceptions).

Resolves: #65
