### PR TITLE
Fix MarkerMetro build menu in Unity

### DIFF
--- a/Assets/Editor/MarkerMetro/CommandLineReader.cs
+++ b/Assets/Editor/MarkerMetro/CommandLineReader.cs
@@ -75,7 +75,7 @@ namespace Assets.Editor.MarkerMetro
             }
             else
             {
-                Debug.LogError("CommandLineReader.cs - GetCommandLine() - Can't find any command line arguments!");
+                Debug.LogWarning("CommandLineReader.cs - GetCommandLine() - Can't find any command line arguments!");
                 return "";
             }
         }
@@ -94,7 +94,7 @@ namespace Assets.Editor.MarkerMetro
             }
             catch (Exception e)
             {
-                Debug.LogError("CommandLineReader.cs - GetCustomArguments() - Can't retrieve any custom arguments in the command line [" + commandLineArgs + "]. Exception: " + e);
+                Debug.LogWarning("CommandLineReader.cs - GetCustomArguments() - Can't retrieve any custom arguments in the command line [" + commandLineArgs + "]. Exception: " + e);
                 return customArgsDict;
             }
 
@@ -127,7 +127,7 @@ namespace Assets.Editor.MarkerMetro
             }
             else
             {
-                Debug.LogError("CommandLineReader.cs - GetCustomArgument() - Can't retrieve any custom argument named [" + argumentName + "] in the command line [" + GetCommandLine() + "].");
+                Debug.LogWarning("CommandLineReader.cs - GetCustomArgument() - Can't retrieve any custom argument named [" + argumentName + "] in the command line [" + GetCommandLine() + "].");
                 return "";
             }
         }

--- a/Assets/Editor/MarkerMetro/MarkerMetroBuilder.cs
+++ b/Assets/Editor/MarkerMetro/MarkerMetroBuilder.cs
@@ -10,14 +10,14 @@ namespace Assets.Editor.MarkerMetro
 {
     public static class MarkerMetroBuilder
     {
-        [MenuItem("MarkerMetro/Build.../All")]
+        [MenuItem("MarkerMetro/Build/All")]
         public static void BuildAll()
         {
             BuildMetro();
             BuildWP8();
         }
 
-        [MenuItem("MarkerMetro/Build.../Windows Store Apps")]
+        [MenuItem("MarkerMetro/Build/Windows Store Apps")]
         public static void BuildMetro()
         {
             string outputPath = MarkerMetro.CommandLineReader.GetCustomArgument("outputPath");
@@ -36,7 +36,7 @@ namespace Assets.Editor.MarkerMetro
                 });
         }
 
-        [MenuItem("MarkerMetro/Build.../Windows Phone 8")]
+        [MenuItem("MarkerMetro/Build/Windows Phone 8")]
         public static void BuildWP8()
         {
             string outputPath = MarkerMetro.CommandLineReader.GetCustomArgument("outputPath");


### PR DESCRIPTION
Make sure MarkerMetro build script works in both Unity Editor and command line build via TC.
