### PR TITLE
Remove email contact picker

### DIFF
--- a/Assets/MarkerMetro/Example/Scripts/GUIStart.cs
+++ b/Assets/MarkerMetro/Example/Scripts/GUIStart.cs
@@ -184,7 +184,7 @@ public class GUIStart : MonoBehaviour {
         // Send an email
         if (GUI.Button(new Rect(box_x + 10, box_y + y_modifier, box_width - 20, 40), "Send Email"))
         {
-            _gameMasterScript.PickContactsAndSendEmail();
+            _gameMasterScript.SendEmail();
         }
 
 #if !UNITY_METRO || UNITY_WP_8_1

--- a/Assets/MarkerMetro/Example/Scripts/GameMaster.cs
+++ b/Assets/MarkerMetro/Example/Scripts/GameMaster.cs
@@ -517,7 +517,7 @@ public class GameMaster : MonoBehaviour {
         ReminderManager.RemoveReminder("testID");
     }
 
-    public void PickContactsAndSendEmail()
+    public void SendEmail()
     {
         Helper.Instance.SendEmail("test@example.com;test2@example.com", "Hello!",
             "This is a test mail.\nBye!");


### PR DESCRIPTION
This PR depends on https://github.com/MarkerMetro/MarkerMetro.Unity.WinIntegration/pull/11 to be approved.

Email contact picker was removed from WinIntegration, so now we are
just sending a test email to an address as a way to desmonstrate the
launcher.

Resolves: #123.
