### PR TITLE
Fix WP8.1 project PreBuildEvent

### DIFF
--- a/WindowsSolutionUniversal/UnityProject/UnityProject.WindowsPhone/UnityProject.WindowsPhone.csproj
+++ b/WindowsSolutionUniversal/UnityProject/UnityProject.WindowsPhone/UnityProject.WindowsPhone.csproj
@@ -230,7 +230,7 @@ echo UnityProjectDir '$(UnityProjectDir)'
 echo Copying assemblies...
 copy /Y "$(ProjectDir)Unprocessed\*" "$(ProjectDir)"
 echo Running AssemblyConverter...
-"$(UnityWSAPlayerDir)\Tools\AssemblyConverter.exe" -platform=wsa81 "$(ProjectDir)\Assembly-CSharp-firstpass.dll" "$(ProjectDir)\Assembly-CSharp.dll" "$(ProjectDir)\LitJson.dll" "$(ProjectDir)\MarkerMetro.Unity.WinLegacy.dll" "$(ProjectDir)\UnityEngine.dll" "$(ProjectDir)\UnityEngine.UI.dll" "$(ProjectDir)\WinRTLegacy.dll" "$(ProjectDir)\Facebook.Client.dll" "$(ProjectDir)\Facebook.dll" "$(ProjectDir)\MarkerMetro.Unity.WinIntegration.dll"
+"$(UnityWSAPlayerDir)\Tools\AssemblyConverter.exe" -platform=wp81 "$(ProjectDir)\Assembly-CSharp-firstpass.dll" "$(ProjectDir)\Assembly-CSharp.dll" "$(ProjectDir)\LitJson.dll" "$(ProjectDir)\MarkerMetro.Unity.WinLegacy.dll" "$(ProjectDir)\UnityEngine.dll" "$(ProjectDir)\UnityEngine.UI.dll" "$(ProjectDir)\WinRTLegacy.dll" "$(ProjectDir)\Facebook.Client.dll" "$(ProjectDir)\Facebook.dll" "$(ProjectDir)\MarkerMetro.Unity.WinIntegration.dll"
 echo AssemblyConverter done.
 </PreBuildEvent>
   </PropertyGroup>


### PR DESCRIPTION
This will fix the problem with Unity failing to load on WindowsPhone 8.1 built from Unity 4.6.2+.
Also tested on Unity 4.6.1 so it won't break it.