### PR TITLE
remove the dialog blocking back button exit on WP8.1

### DIFF
--- a/Assets/MarkerMetro/Example/Scripts/GUIMain.cs
+++ b/Assets/MarkerMetro/Example/Scripts/GUIMain.cs
@@ -47,18 +47,7 @@ namespace MarkerMetro.Unity.WinShared.Example
 
         void Update()
         {
-#if (UNITY_WP8 || UNITY_WP_8_1) && !UNITY_EDITOR
-        if (Input.GetKeyDown(KeyCode.Escape))
-        {
-            MarkerMetro.Unity.WinIntegration.Helper.Instance.ShowDialog("Are you sure you want to quit?", "Quit Confirm", (okPressed) =>
-            {
-                if (okPressed)
-                {
-                    Application.Quit();
-                }
-            }, "Yes", "No");
-        }
-#endif
+
         }
 
         void OnGUI()


### PR DESCRIPTION
should find that pressing back button will not be handled by unity now and the app closes cleanly on WP8.1 and the live tiles update. There is still a Quit button in the scene which will call Application.Quit, anything that calls this on WP8.1 will cause the app to crash out, and normal lifecycle flow will not occur (e.g. OnVisibilityChanged etc.). There is no way to programmatically invoke the back button after displaying a message dialog, so they should be avoided. If they do end up getting used on a game, then the side effect is no live tile processing, unless the player uses windows key (which most do) rather than back button to exit game. 

Will test this in morning when i can deploy to phone and update.