### PR TITLE
Fix LitJson import settings for Unity 5.0.2f1

### DIFF
--- a/Assets/Plugins/Metro/LitJson.dll.meta
+++ b/Assets/Plugins/Metro/LitJson.dll.meta
@@ -35,6 +35,10 @@ PluginImporter:
       enabled: 0
       settings:
         CPU: AnyCPU
+    SamsungTV:
+      enabled: 0
+      settings:
+        STV_MODEL: STANDARD_13
     WP8:
       enabled: 0
       settings:
@@ -54,7 +58,7 @@ PluginImporter:
       settings:
         CPU: AnyCPU
         DontProcess: True
-        PlaceholderPath: 
+        PlaceholderPath: Assets/Plugins/LitJson.dll
         SDK: AnySDK
     iOS:
       enabled: 0


### PR DESCRIPTION
It'll still work in Unity5.0.1.