### PR TITLE
Prevent click-through when game-settings is open.

### DIFF
--- a/WindowsSolutionUniversal/UnityProject/UnityProject.Windows/GameSettingsFlyout.xaml.cs
+++ b/WindowsSolutionUniversal/UnityProject/UnityProject.Windows/GameSettingsFlyout.xaml.cs
@@ -41,14 +41,35 @@ namespace UnityProject.Win
             this.Unloaded += GameSettingsFlyout_Unloaded;
         }
 
+        bool inputDisableByThis;
+
         void GameSettingsFlyout_Loaded(object sender, RoutedEventArgs e)
         {
+            inputDisableByThis = true;
             UnityPlayer.AppCallbacks.Instance.UnitySetInput(false);
+
+            var parent = Parent as Popup;
+
+            if (parent != null)
+                parent.Closed += parent_Closed;
+        }
+
+        void parent_Closed(object sender, object e)
+        {
+            if (inputDisableByThis)
+            {
+                inputDisableByThis = false;
+                UnityPlayer.AppCallbacks.Instance.UnitySetInput(true);
+            }
         }
 
         void GameSettingsFlyout_Unloaded(object sender, RoutedEventArgs e)
         {
-            UnityPlayer.AppCallbacks.Instance.UnitySetInput(true);
+            if (inputDisableByThis)
+            {
+                inputDisableByThis = false;
+                UnityPlayer.AppCallbacks.Instance.UnitySetInput(true);
+            }
         }
 
         public void ActivateSound(bool active)

--- a/WindowsSolutionUniversal/UnityProject/UnityProject.Windows/GameSettingsFlyout.xaml.cs
+++ b/WindowsSolutionUniversal/UnityProject/UnityProject.Windows/GameSettingsFlyout.xaml.cs
@@ -36,6 +36,19 @@ namespace UnityProject.Win
             musicSwitch.IsOn = GameController.Instance.GameSettings.MusicEnabled;
             soundSwitch.IsOn = GameController.Instance.GameSettings.SoundEnabled;
             reminderSwitch.IsOn = GameController.Instance.GameSettings.RemindersEnabled;
+
+            this.Loaded += GameSettingsFlyout_Loaded;
+            this.Unloaded += GameSettingsFlyout_Unloaded;
+        }
+
+        void GameSettingsFlyout_Loaded(object sender, RoutedEventArgs e)
+        {
+            UnityPlayer.AppCallbacks.Instance.UnitySetInput(false);
+        }
+
+        void GameSettingsFlyout_Unloaded(object sender, RoutedEventArgs e)
+        {
+            UnityPlayer.AppCallbacks.Instance.UnitySetInput(true);
         }
 
         public void ActivateSound(bool active)


### PR DESCRIPTION
Unity input is now manually disabled when the game-settings flyout is open.
https://trello.com/c/Okvd6jhR