### PR TITLE
Re-add listener to WindowVisibilityChanged event

### DIFF
--- a/WindowsSolutionUniversal/UnityProject/UnityProject.Shared/MainPage.xaml.cs
+++ b/WindowsSolutionUniversal/UnityProject/UnityProject.Shared/MainPage.xaml.cs
@@ -85,6 +85,7 @@ namespace UnityProject
 
             onResizeHandler = new WindowSizeChangedEventHandler((o, e) => OnResize());
             Window.Current.SizeChanged += onResizeHandler;
+            Window.Current.VisibilityChanged += OnWindowVisibilityChanged;
 
 #if UNITY_WP_8_1
             SetupLocationService();


### PR DESCRIPTION
Was removed by mistake when we updated the project to 5.2